### PR TITLE
obey rate limits

### DIFF
--- a/users.go
+++ b/users.go
@@ -199,7 +199,10 @@ pagination:
 			response, err = userRequest(ctx, "users.list", values, api.debug)
 			if err != nil {
 				if e, ok := err.(WebError); ok && e.Status == 429 {
-					time.Sleep(time.Duration(e.RetryAfter+1) * time.Second)
+					if api.debug {
+						logger.Printf("GetUsersContext: users.list rate limited, sleeping for %d seconds", e.RetryAfter)
+					}
+					time.Sleep(time.Duration(e.RetryAfter) * time.Second)
 					continue retry
 				}
 				return nil, err
@@ -207,6 +210,9 @@ pagination:
 			break retry
 		}
 		users = append(users, response.Members...)
+		if api.debug {
+			logger.Printf("GetUsersContext: got %d users; now %d total", len(response.Members), len(users))
+		}
 		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok && next_token != "" {
 			values["cursor"] = []string{next_token}
 		} else {

--- a/users.go
+++ b/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
 	"time"
 )
@@ -208,7 +207,7 @@ pagination:
 			break retry
 		}
 		users = append(users, response.Members...)
-		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok {
+		if next_token, ok := response.ResponseMetadata["next_cursor"]; ok && next_token != "" {
 			values["cursor"] = []string{next_token}
 		} else {
 			break pagination

--- a/users.go
+++ b/users.go
@@ -186,7 +186,7 @@ func (api *Client) GetUsersContext(ctx context.Context) (users []User, err error
 		// quickly, so we'll have to be bad little citizens and
 		// use the max. :-/
 		"limit":    {"1000"},
-		"presence": {"false"},
+		"presence": {"true"},
 		"token":    {api.config.token},
 	}
 


### PR DESCRIPTION
The 429 response from the server in case of rate limit includes a `retry-after` header telling us how long to sleep; surface that information to the caller so we can obey it.

Then, implement a retry loop around `users.list` to sleep and retry ratelimits called.